### PR TITLE
Follow standard naming for the textdomain

### DIFF
--- a/src/lib/systemd_journal/entries_dialog.rb
+++ b/src/lib/systemd_journal/entries_dialog.rb
@@ -30,7 +30,7 @@ module SystemdJournal
   class EntriesDialog < UI::Dialog
     def initialize
       super
-      textdomain "systemd_journal"
+      textdomain "journal"
 
       @query = QueryPresenter.new
       execute_query

--- a/src/lib/systemd_journal/query_dialog.rb
+++ b/src/lib/systemd_journal/query_dialog.rb
@@ -39,7 +39,7 @@ module SystemdJournal
 
     def initialize(query)
       super()
-      textdomain "systemd_journal"
+      textdomain "journal"
       @query = query
     end
 

--- a/src/lib/systemd_journal/query_presenter.rb
+++ b/src/lib/systemd_journal/query_presenter.rb
@@ -26,12 +26,12 @@ module SystemdJournal
   class QueryPresenter < SimpleDelegator
     include Yast::I18n
     extend Yast::I18n
-    textdomain "systemd_journal"
+    textdomain "journal"
 
     TIME_FORMAT = "%b %d %H:%M:%S"
 
     def initialize(args = {})
-      textdomain "systemd_journal"
+      textdomain "journal"
 
       # Redefine default values
       query_args = {


### PR DESCRIPTION
I'll increase the version name after merging this and https://github.com/yast/yast-journal/pull/15 to avoid too much version bump with no real value for the user.