### PR TITLE
Fixed a crash when running as a non-root user (bsc#1089626) [SLES12-SP4] 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ YaST systemd journal module
 A module for [YaST](http://yast.github.io) to read the systemd journal in a
 user-friendly way.
 
+### Notes
+
+- This module can be used by non-root users. By default the non-root users
+  do not have the permission to read the journal, to allow specific users
+  reading the journal add them to the `systemd-journal` user group.
+
 Further information
 -------------------
 

--- a/package/yast2-journal.changes
+++ b/package/yast2-journal.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 28 11:17:02 UTC 2018 - lslezak@suse.cz
+
+- Do not crash when changing the filter as a non-root user
+  (bsc#1089626)
+- 3.2.2
+
+-------------------------------------------------------------------
 Tue Aug 29 10:04:29 UTC 2017 - knut.anderssen@suse.com
 
 - Escape special search query characters (bsc#1055500)

--- a/package/yast2-journal.spec
+++ b/package/yast2-journal.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-journal
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/systemd_journal/journalctl.rb
+++ b/src/lib/systemd_journal/journalctl.rb
@@ -16,6 +16,8 @@
 #  To contact SUSE about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 
+require "systemd_journal/journalctl_exception"
+
 module SystemdJournal
   # Wrapper for journalctl invocation
   class Journalctl
@@ -71,7 +73,7 @@ module SystemdJournal
         # Most likely, journalctl bug when an empty list is found
         ""
       else
-        raise "Calling journalctl failed: #{cmd_result["stderr"]}"
+        raise JournalctlException, cmd_result["stderr"]
       end
     end
 

--- a/src/lib/systemd_journal/journalctl_exception.rb
+++ b/src/lib/systemd_journal/journalctl_exception.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2018 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+module SystemdJournal
+  # Exception for a failed journalctl invocation
+  class JournalctlException < RuntimeError
+  end
+end

--- a/test/entries_dialog_test.rb
+++ b/test/entries_dialog_test.rb
@@ -1,0 +1,59 @@
+#! /usr/bin/rspec
+# Copyright (c) 2014 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+require_relative "spec_helper"
+require "systemd_journal/entries_dialog"
+require "systemd_journal/journalctl_exception"
+
+describe SystemdJournal::EntriesDialog do
+  # journalctl error message
+  let(:details) { "failed!" }
+
+  before do
+    # the query is executed in the constructor
+    allow_any_instance_of(SystemdJournal::Query).to receive(:execute)
+  end
+
+  describe "#dialog_content" do
+    it "returns Term" do
+      expect(subject.dialog_content).to be_a(Yast::Term)
+    end
+  end
+
+  describe "#dialog_options" do
+    it "returns Term" do
+      expect(subject.dialog_options).to be_a(Yast::Term)
+    end
+  end
+
+  describe "#filter_handler" do
+    it "reports an error when journalctl fails" do
+      expect_any_instance_of(SystemdJournal::QueryDialog).to receive(:run)
+        .and_raise(SystemdJournal::JournalctlException, details)
+      expect(Yast::Popup).to receive(:MessageDetails).with(anything, details)
+
+      # mock the other methods
+      allow(subject).to receive(:redraw_query)
+      allow(subject).to receive(:execute_query)
+      allow(subject).to receive(:redraw_table)
+
+      expect { subject.filter_handler }.to_not raise_error
+    end
+  end
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -77,3 +77,12 @@ def json_for(name)
   file = File.join(DATA_PATH, "#{name}-entry.json")
   File.open(file, encoding: "UTF-8", &:read)
 end
+
+# configure RSpec
+RSpec.configure do |config|
+  config.mock_with :rspec do |c|
+    # verify that the mocked methods are really defined
+    # https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/partial-doubles
+    c.verify_partial_doubles = true
+  end
+end


### PR DESCRIPTION
- Fixed a crash when running as a non-root user
- Added a new specific exception, rescue only this new exception (no catch-them-all handling which might hide other problems)
- Display a translated error message
- Updated README - describe how to allow non-root access
- Backported the unit test from `master`
- Enabled verifying doubles in the tests
- 3.2.2

## Screenshots

### The Crash

Originally after pressing the "Change Filter..." button the module crashed when running as a non-root user.

![journal_crash](https://user-images.githubusercontent.com/907998/44720873-794bec00-aac8-11e8-90c6-6b4f7bc55c17.png)


### Fix

Now a translated error message is displayed.

![journal_fixed](https://user-images.githubusercontent.com/907998/44720891-8cf75280-aac8-11e8-8080-ddf39c985d6a.png)

The (not translated) details can be displayed after pressing the "Details..." button

![journal_fixed_details](https://user-images.githubusercontent.com/907998/44720934-a7313080-aac8-11e8-9c50-0c0c4be5c9ae.png)
.