### PR TITLE
Prompt for root password.

### DIFF
--- a/src/desktop/journal.desktop
+++ b/src/desktop/journal.desktop
@@ -15,7 +15,7 @@ X-SuSE-YaST-SortKey=
 X-SuSE-YaST-AutoInstResource=
 
 Icon=yast-journal
-Exec=/sbin/yast2 journal
+Exec=xdg-su -c "/sbin/yast2 journal"
 
 Name=Systemd Journal
 GenericName=Read systemd journal entries


### PR DESCRIPTION
When launched independently, eg from gnome-shell, this module fails because it runs as non-root.
See https://bugzilla.suse.com/show_bug.cgi?id=1132573