### PR TITLE
show more verbose message when journal can't be read (bsc#1132658)

### DIFF
--- a/package/yast2-journal.changes
+++ b/package/yast2-journal.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  7 13:11:33 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
+
+- show more verbose message when journal can't be read (bsc#1132658)
+- 4.2.0
+
+-------------------------------------------------------------------
 Fri Dec  7 08:57:35 UTC 2018 - jreidinger@suse.com
 
 - always use absolute path to binaries (bsc#1118291)

--- a/package/yast2-journal.spec
+++ b/package/yast2-journal.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-journal
-Version:        4.1.5
+Version:        4.2.0
 Release:        0
 BuildArch:      noarch
 

--- a/src/lib/y2journal/entries_dialog.rb
+++ b/src/lib/y2journal/entries_dialog.rb
@@ -184,7 +184,13 @@ module Y2Journal
     #
     def journalctl_failed(details)
       log.warn "journalctl failed, displaying empty result"
-      Yast2::Popup.show(_("Reading the journal entries failed."), details: details)
+      Yast2::Popup.show(
+        _(
+          "Reading system messages failed.\n\n" \
+          "Only users in the 'systemd-journal' group or user 'root'\n" \
+          "can read all system messages."
+        ), details: details
+      )
     end
   end
 end


### PR DESCRIPTION
### Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1132658

Give more verbose feedback when systemd journal can't be read.

### Scrum board

https://trello.com/c/xO25c7am

### Related

https://github.com/yast/yast-yast2/pull/924