### PR TITLE
Fixed build failure (reverted back the original test command)

### DIFF
--- a/package/yast2-journal.spec
+++ b/package/yast2-journal.spec
@@ -55,7 +55,8 @@ user-friendly way.
 %setup -q
 
 %check
-%yast_check
+# Enable UI tests in headless systems like Jenkins
+libyui-terminal rake test:unit
 
 %install
 %yast_install


### PR DESCRIPTION
- Fix up for #42 
- Use back the `screen` wrapper for running the tests, the tests really use the UI.