### PR TITLE
Fix help

### DIFF
--- a/package/yast2-journal.changes
+++ b/package/yast2-journal.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 19 12:12:33 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- print properly help to avoid accidental opening of module by bash
+  completion (bsc#1172340)
+- 4.3.0
+
+-------------------------------------------------------------------
 Mon Aug 26 09:20:29 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-journal.spec
+++ b/package/yast2-journal.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-journal
-Version:        4.2.2
+Version:        4.3.0
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0 or GPL-3.0

--- a/src/clients/journal.rb
+++ b/src/clients/journal.rb
@@ -24,4 +24,3 @@ if Yast::WFM.Args.empty?
 else
   Y2Journal::CLI.run
 end
-

--- a/src/lib/y2journal/cli.rb
+++ b/src/lib/y2journal/cli.rb
@@ -16,12 +16,26 @@
 #  To contact Novell about this file by physical or electronic mail,
 #  you may find current contact information at www.suse.com
 
-require "y2journal/entries_dialog"
-require "y2journal/cli"
+Yast.import "CommandLine"
 
-if Yast::WFM.Args.empty?
-  Y2Journal::EntriesDialog.run
-else
-  Y2Journal::CLI.run
+module Y2Journal
+  class CLI
+    extend Yast::I18n
+
+    def self.run
+      textdomain "journal"
+
+      msg = format(
+        _("Command line is not supported. Use '%s' directly."),
+        "journalctl"
+      )
+
+      cmdline_description = {
+        "id"   => "journal",
+        "help" => msg
+      }
+
+      Yast::CommandLine.Run(cmdline_description)
+    end
+  end
 end
-

--- a/src/lib/y2journal/cli.rb
+++ b/src/lib/y2journal/cli.rb
@@ -19,6 +19,7 @@
 Yast.import "CommandLine"
 
 module Y2Journal
+  # CLI support for journal. It just recommends to run journalctl directly.
   class CLI
     extend Yast::I18n
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,32 @@
+#! /usr/bin/rspec
+# Copyright (c) 2014 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+require_relative "spec_helper"
+
+require "y2journal/cli"
+
+describe Y2Journal::CLI do
+  describe ".run" do
+    it "prints command line output" do
+      expect(Yast::CommandLine).to receive(:Run)
+
+      described_class.run
+    end
+  end
+end


### PR DESCRIPTION
## Problem

double tab on CLI opens a module.

- https://bugzilla.suse.com/show_bug.cgi?id=1172340
- https://trello.com/c/8G4FikEf/1988-ostumbleweed-p5-1172340-several-yast-modules-can-be-started-by-typing-yast2-module-tabtab

## Solution

Print properly that CLI is not supported. Also add built in help for partitioner_testing client.


## Testing

- *Tested manually*