### PR TITLE
Prevent Escape Sequences in the JSON Output

### DIFF
--- a/package/yast2-journal.changes
+++ b/package/yast2-journal.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan  4 13:40:35 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Make sure not to get escape sequences (for colors) into the 
+  output of the 'journalctl --output json' command, even if
+  $SYSTEMD_COLORS is set in the environment (bsc#1218106)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-journal.spec
+++ b/package/yast2-journal.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-journal
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0 or GPL-3.0

--- a/src/lib/y2journal/journalctl.rb
+++ b/src/lib/y2journal/journalctl.rb
@@ -59,7 +59,7 @@ module Y2Journal
 
     # Full journalctl command
     def command
-      "LANG=C /usr/bin/journalctl #{options_string} #{matches_string}".strip.squeeze(" ")
+      "SYSTEMD_COLORS='' LANG=C /usr/bin/journalctl #{options_string} #{matches_string}".strip.squeeze(" ")
     end
 
     # Output resulting of executing the command


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1218106


## Problem

In some environments, `yast2 journal` crashes: There are escape sequences in the data to be displayed, which lead to a syntax error.


## Cause

The `SYSTEMD_COLORS` environment variable overrides the tty detection of the `journalctl --output json` command: Even if the output is redirected to a file or a pipeline, it still contains the escape sequences for colored output, which makes the output parser in YaST fail.

That is very odd since the purpose of JSON output is machine-readable, but the man page documents that behavior.

How and why that environment variable is set so this happens when YaST calls that command is not quite clear, but it happened, albeit only on Tumbleweed.


## Fix

Override the override: Explicitly set `SYSTEMD_COLORS=''` (to nothing) for that command invocation.


## Test

```
SYSTEMD_COLORS=256 yast2 journal
```

(Yes, this module can be run as a normal user, unlike most YaST modules)

Without this fix: Crash.

With this fix: No crash.